### PR TITLE
修复 Memory Browser 默认落点并避免前端旧壳缓存

### DIFF
--- a/deploy/docker/nginx.conf.template
+++ b/deploy/docker/nginx.conf.template
@@ -51,6 +51,11 @@ server {
     proxy_read_timeout 3600s;
   }
 
+  location = /index.html {
+    add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+    try_files /index.html =404;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,8 @@ import {
 } from './lib/api';
 import { CHINESE_LOCALE, DEFAULT_LOCALE } from './i18n';
 
+const DEFAULT_MEMORY_ROUTE = '/memory?domain=notes&path=projects';
+
 function NavItem({ to, icon: Icon, label }) {
   return (
     <NavLink
@@ -158,7 +160,7 @@ function Layout({ authState, authRevision, onOpenSetup, onClearApiKey }) {
             animate={{ opacity: 1, y: 0 }}
             className="flex min-w-0 max-w-full items-center gap-1 overflow-x-auto rounded-full border border-white/30 bg-white/20 p-1.5 backdrop-blur-xl shadow-[0_8px_32px_rgba(179,133,79,0.05)] scrollbar-hide"
           >
-            <NavItem to="/memory" icon={Database} label={t('app.nav.memory')} />
+            <NavItem to={DEFAULT_MEMORY_ROUTE} icon={Database} label={t('app.nav.memory')} />
             <NavItem to="/review" icon={ShieldCheck} label={t('app.nav.review')} />
             <NavItem to="/maintenance" icon={Feather} label={t('app.nav.maintenance')} />
             <NavItem to="/observability" icon={Eye} label={t('app.nav.observability')} />
@@ -179,12 +181,12 @@ function Layout({ authState, authRevision, onOpenSetup, onClearApiKey }) {
       <div className="relative z-10 flex-1 min-h-0 overflow-hidden px-6 pb-6 pt-2">
         <div className="h-full w-full max-w-7xl mx-auto">
             <Routes key={routesKey}>
-              <Route path="/" element={<Navigate to="/memory" replace />} />
+              <Route path="/" element={<Navigate to={DEFAULT_MEMORY_ROUTE} replace />} />
               <Route path="/review" element={<ReviewPage />} />
               <Route path="/memory" element={<MemoryBrowser />} />
               <Route path="/maintenance" element={<MaintenancePage />} />
               <Route path="/observability" element={<ObservabilityPage />} />
-              <Route path="*" element={<Navigate to="/memory" replace />} />
+              <Route path="*" element={<Navigate to={DEFAULT_MEMORY_ROUTE} replace />} />
             </Routes>
         </div>
       </div>

--- a/frontend/src/features/memory/MemoryBrowser.jsx
+++ b/frontend/src/features/memory/MemoryBrowser.jsx
@@ -13,6 +13,7 @@ import {
   Folder,
   Home,
   Plus,
+  RefreshCw,
   Save,
   Search,
   Sparkles,
@@ -37,6 +38,7 @@ const isAbortError = (error) =>
         error.name === 'CanceledError')
   );
 const CHILD_PAGE_SIZE = 50;
+const BROWSABLE_DOMAINS = ['core', 'notes', 'writer', 'game'];
 
 function CrumbBar({ items, onNavigate }) {
   const { t } = useTranslation();
@@ -102,8 +104,11 @@ export default function MemoryBrowser() {
   const { t } = useTranslation();
   const defaultConversation = t('memory.defaultConversation');
   const [searchParams, setSearchParams] = useSearchParams();
-  const domain = searchParams.get('domain') || 'core';
-  const path = searchParams.get('path') || '';
+  const hasDomainParam = searchParams.has('domain');
+  const hasPathParam = searchParams.has('path');
+  const shouldUseProjectNotesDefault = !hasDomainParam && !hasPathParam;
+  const domain = shouldUseProjectNotesDefault ? 'notes' : (searchParams.get('domain') || 'core');
+  const path = shouldUseProjectNotesDefault ? 'projects' : (searchParams.get('path') || '');
 
   const [loading, setLoading] = useState(true);
   const [errorState, setErrorState] = useState(null);
@@ -132,6 +137,14 @@ export default function MemoryBrowser() {
   const nodeAbortControllerRef = useRef(null);
 
   const isRoot = !path;
+  useEffect(() => {
+    if (!shouldUseProjectNotesDefault) return;
+    const params = new URLSearchParams();
+    params.set('domain', 'notes');
+    params.set('path', 'projects');
+    setSearchParams(params, { replace: true });
+  }, [setSearchParams, shouldUseProjectNotesDefault]);
+
   const error = useMemo(() => {
     if (!errorState) return null;
     return extractApiError(errorState.error, t(errorState.fallbackKey));
@@ -185,6 +198,11 @@ export default function MemoryBrowser() {
       || editPriority !== (data.node.priority ?? 0)
     );
   }, [data.node, editContent, editDisclosure, editPriority, editing, isRoot]);
+  const canAutoRefresh = !hasUnsavedNodeEdit && !editing && !creating && !saving && !deleting;
+  const domainOptions = useMemo(() => {
+    if (BROWSABLE_DOMAINS.includes(domain)) return BROWSABLE_DOMAINS;
+    return [domain, ...BROWSABLE_DOMAINS];
+  }, [domain]);
 
   useEffect(() => {
     if (!hasUnsavedNodeEdit) return undefined;
@@ -197,6 +215,22 @@ export default function MemoryBrowser() {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [hasUnsavedNodeEdit]);
+
+  useEffect(() => {
+    if (!canAutoRefresh) return undefined;
+
+    const handleRefreshSignal = () => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+      void refreshNode();
+    };
+
+    window.addEventListener('focus', handleRefreshSignal);
+    document.addEventListener('visibilitychange', handleRefreshSignal);
+    return () => {
+      window.removeEventListener('focus', handleRefreshSignal);
+      document.removeEventListener('visibilitychange', handleRefreshSignal);
+    };
+  }, [canAutoRefresh, refreshNode]);
 
   const navigateTo = (nextPath, nextDomain = domain, { force = false } = {}) => {
     const sameTarget = nextDomain === domain && nextPath === path;
@@ -213,6 +247,14 @@ export default function MemoryBrowser() {
     if (nextPath) params.set('path', nextPath);
     setSearchParams(params);
     return true;
+  };
+
+  const onRefreshNode = async () => {
+    if (hasUnsavedNodeEdit && !window.confirm(t('memory.prompts.discardNodeChanges'))) {
+      return;
+    }
+    setFeedback(null);
+    await refreshNode();
   };
 
   const visibleChildren = useMemo(() => {
@@ -371,10 +413,49 @@ export default function MemoryBrowser() {
               {isRoot ? t('memory.rootTitle') : (data.node?.name || path.split('/').pop())}
             </h1>
           </div>
-          <div className="flex items-center gap-3">
-             <div className="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/20 px-4 py-1.5 text-xs font-medium text-[color:var(--palace-muted)] backdrop-blur-md shadow-sm">
-              <Sparkles size={13} className="text-[color:var(--palace-accent)]" />
-              {domain}://{path || 'root'}
+          <div className="flex flex-col items-end gap-3">
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  void onRefreshNode();
+                }}
+                className="palace-btn-ghost bg-white/50"
+              >
+                <RefreshCw size={14} className={clsx(loading && 'animate-spin')} />
+                {t('memory.refreshNode')}
+              </button>
+              <div className="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/20 px-4 py-1.5 text-xs font-medium text-[color:var(--palace-muted)] backdrop-blur-md shadow-sm">
+                <Sparkles size={13} className="text-[color:var(--palace-accent)]" />
+                {domain}://{path || 'root'}
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <span className="text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--palace-muted)]">
+                {t('memory.browseScope')}
+              </span>
+              {domainOptions.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => navigateTo('', option)}
+                  className={clsx(
+                    'rounded-full border px-3 py-1 text-xs font-semibold transition',
+                    option === domain
+                      ? 'border-[color:var(--palace-accent)]/30 bg-[color:var(--palace-accent)]/12 text-[color:var(--palace-accent-2)]'
+                      : 'border-white/40 bg-white/30 text-[color:var(--palace-muted)] hover:bg-white/55 hover:text-[color:var(--palace-ink)]'
+                  )}
+                >
+                  {t(`memory.domainLabels.${option}`)}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => navigateTo('projects', 'notes')}
+                className="rounded-full border border-white/40 bg-white/30 px-3 py-1 text-xs font-semibold text-[color:var(--palace-muted)] transition hover:bg-white/55 hover:text-[color:var(--palace-ink)]"
+              >
+                {t('memory.projectNotesRoot')}
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/features/memory/MemoryBrowser.test.jsx
+++ b/frontend/src/features/memory/MemoryBrowser.test.jsx
@@ -279,4 +279,42 @@ describe('MemoryBrowser', () => {
 
     expect(await screen.findByText('memory-55')).toBeInTheDocument();
   });
+
+  it('offers visible domain switching and a quick jump to project notes', async () => {
+    const user = userEvent.setup();
+    api.getMemoryNode.mockResolvedValue(ROOT_PAYLOAD);
+
+    renderMemoryBrowser('/memory?domain=core');
+
+    await screen.findByText(i18n.t('memory.rootNodeTitle'));
+
+    await user.click(screen.getByRole('button', { name: i18n.t('memory.domainLabels.notes') }));
+    await waitFor(() => {
+      expect(api.getMemoryNode).toHaveBeenLastCalledWith(
+        { domain: 'notes', path: '' },
+        expect.any(Object)
+      );
+    });
+
+    await user.click(screen.getByRole('button', { name: i18n.t('memory.projectNotesRoot') }));
+    await waitFor(() => {
+      expect(api.getMemoryNode).toHaveBeenLastCalledWith(
+        { domain: 'notes', path: 'projects' },
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('defaults bare /memory to the project notes scope', async () => {
+    api.getMemoryNode.mockResolvedValue(ROOT_PAYLOAD);
+
+    renderMemoryBrowser('/memory');
+
+    await waitFor(() => {
+      expect(api.getMemoryNode).toHaveBeenLastCalledWith(
+        { domain: 'notes', path: 'projects' },
+        expect.any(Object)
+      );
+    });
+  });
 });

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -265,6 +265,9 @@ const en = {
     priorityPlaceholder: 'Priority',
     disclosurePlaceholder: 'Disclosure',
     storeMemory: 'Store Memory',
+    refreshNode: 'Refresh View',
+    browseScope: 'Browse scope',
+    projectNotesRoot: 'Open project notes',
     childFilters: 'Child Filters',
     searchPlaceholder: 'Search path / snippet',
     maxPriorityPlaceholder: 'Max priority (optional)',
@@ -285,6 +288,12 @@ const en = {
     noChildMatches: 'No child memory matches current filter.',
     showingChildren: 'Showing {{shown}} of {{total}} child memories.',
     loadMoreChildren: 'Load {{count}} more',
+    domainLabels: {
+      core: 'Core',
+      notes: 'Notes',
+      writer: 'Writer',
+      game: 'Game',
+    },
     gistView: 'Gist',
     originalView: 'Original',
     feedback: {

--- a/frontend/src/locales/zh-CN.js
+++ b/frontend/src/locales/zh-CN.js
@@ -265,6 +265,9 @@ const zhCN = {
     priorityPlaceholder: '优先级',
     disclosurePlaceholder: '披露条件',
     storeMemory: '写入记忆',
+    refreshNode: '刷新当前视图',
+    browseScope: '浏览范围',
+    projectNotesRoot: '打开项目记忆目录',
     childFilters: '子节点筛选',
     searchPlaceholder: '搜索路径 / 摘要',
     maxPriorityPlaceholder: '最高优先级（可选）',
@@ -285,6 +288,12 @@ const zhCN = {
     noChildMatches: '当前筛选条件下没有匹配的子记忆。',
     showingChildren: '当前显示 {{shown}} / {{total}} 条子记忆。',
     loadMoreChildren: '再加载 {{count}} 条',
+    domainLabels: {
+      core: '核心',
+      notes: '笔记',
+      writer: '写作',
+      game: '游戏',
+    },
     gistView: '摘要',
     originalView: '原文',
     feedback: {


### PR DESCRIPTION
## 变更说明

这个 PR 主要修复 Memory Browser 在项目记忆场景下两个比较容易造成误解的问题：

1. 裸 `/memory` 默认会进入 `core` 根节点，用户更容易只看到少量 `core://...` 条目，而看不到实际按项目组织的 `notes://projects/...` 目录。
2. 前端部署更新后，`index.html` 可能被浏览器或代理继续缓存，导致同一个 `/memory` 路径在不同访问情况下看起来像“两个不同页面”。

## 具体修改

- 将默认 Memory 页面入口调整为 `notes://projects`
  - 导航栏中的 Memory 入口默认跳转到 `/memory?domain=notes&path=projects`
  - 根路由和兜底路由也统一跳转到这个默认入口
  - 当用户直接访问裸 `/memory` 时，前端会自动归一化到项目记忆目录
- 增强 Memory Browser 的可达性
  - 增加 domain 切换按钮
  - 增加“打开项目记忆目录”快捷入口
  - 增加“刷新当前视图”按钮
  - 增加窗口重新聚焦/可见时的自动刷新
- 为中英文文案补充上述新入口和按钮文本
- 为裸 `/memory` 默认跳转到项目目录补充测试
- 为前端 `index.html` 增加 `Cache-Control: no-store, no-cache, must-revalidate`
  - 减少部署后继续命中旧前端壳的问题

## 影响

这次修改不会改变底层 Memory Palace 的存储结构，也不会改变已有的 memory URI。
它主要改善的是默认入口和前端可见性，让项目记忆目录更容易被直接访问，同时降低前端缓存导致的展示不一致问题。

## 验证

已验证：

- `npm test -- --run src/features/memory/MemoryBrowser.test.jsx src/App.test.jsx`
- `npm run build`
